### PR TITLE
Align Android status bar style with theme

### DIFF
--- a/android/app/src/main/java/com/my/vivica/MainActivity.java
+++ b/android/app/src/main/java/com/my/vivica/MainActivity.java
@@ -2,8 +2,9 @@ package com.my.vivica;
 
 import android.os.Bundle;
 import android.view.Window;
-import android.view.WindowManager;
 import androidx.core.content.ContextCompat;
+import androidx.core.graphics.ColorUtils;
+import androidx.core.view.WindowInsetsControllerCompat;
 import com.getcapacitor.BridgeActivity;
 
 public class MainActivity extends BridgeActivity {
@@ -17,5 +18,11 @@ public class MainActivity extends BridgeActivity {
     Window window = getWindow();
     int statusBarColor = ContextCompat.getColor(this, R.color.status_bar_color);
     window.setStatusBarColor(statusBarColor);
+
+    // Ensure status bar icons contrast against the background color
+    WindowInsetsControllerCompat controller =
+        new WindowInsetsControllerCompat(window, window.getDecorView());
+    boolean isLight = ColorUtils.calculateLuminance(statusBarColor) > 0.5;
+    controller.setAppearanceLightStatusBars(isLight);
   }
 }


### PR DESCRIPTION
## Summary
- ensure Android status bar icons contrast with the current background color

## Testing
- `npm run lint`
- `./gradlew assembleDebug` *(fails: capacitor-cordova-android-plugins/cordova.variables.gradle missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a032e08250832a889142c43ef52bb5