### PR TITLE
feat: add status bar theme helper

### DIFF
--- a/android/app/src/main/java/com/my/vivica/MainActivity.java
+++ b/android/app/src/main/java/com/my/vivica/MainActivity.java
@@ -16,7 +16,7 @@ public class MainActivity extends BridgeActivity {
     // Set an initial status bar color. The web app updates this dynamically
     // to match the active theme via the Capacitor StatusBar plugin.
     Window window = getWindow();
-    int statusBarColor = ContextCompat.getColor(this, R.color.status_bar_color);
+    int statusBarColor = ContextCompat.getColor(this, R.color.statusbar_color);
     window.setStatusBarColor(statusBarColor);
 
     // Ensure status bar icons contrast against the background color

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <!-- Maintain modern dark theme color palette -->
-  <color name="status_bar_color">#121212</color>
+  <color name="statusbar_color">#0B0512</color>
   <color name="primary_color">#1C1C1C</color>
   <color name="card_background">#292929</color>
   <color name="accent_color">#6200EE</color>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-    <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
-        <!-- Customize your theme here. -->
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@color/statusbar_color</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
-
-    <style name="AppTheme.NoActionBar" parent="Theme.AppCompat.DayNight.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-        <item name="android:background">@null</item>
-    </style>
-
 
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
         <item name="android:background">@drawable/splash</item>

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -1,26 +1,12 @@
-
 import {
   useState,
   useEffect,
   createContext,
   useContext,
 } from 'react';
-import { StatusBar, Style } from '@capacitor/status-bar';
-import { Capacitor } from '@capacitor/core';
+import { applyStatusBarTheme, ThemeKey, ThemeFamily } from '@/lib/statusBar';
 import { Storage, DebouncedStorage, STORAGE_KEYS } from '@/utils/storage';
 import { useDynamicTheme } from '@/hooks/useDynamicTheme';
-
-const hslToHex = (h: number, s: number, l: number) => {
-  s /= 100;
-  l /= 100;
-  const k = (n: number) => (n + h / 30) % 12;
-  const a = s * Math.min(l, 1 - l);
-  const f = (n: number) =>
-    Math.round((l - a * Math.max(-1, Math.min(Math.min(k(n) - 3, 9 - k(n)), 1))) * 255)
-      .toString(16)
-      .padStart(2, '0');
-  return `#${f(0)}${f(8)}${f(4)}`;
-};
 
 export type ThemeVariant = 'dark' | 'light';
 export type ThemeColor =
@@ -66,26 +52,20 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
   }, [color, variant]);
 
   useEffect(() => {
-    const applyStatusBar = async () => {
-      if (!Capacitor.isNativePlatform()) return;
-      try {
-        const rootStyles = getComputedStyle(document.documentElement);
-        const hsl = rootStyles.getPropertyValue('--background').trim();
-        let hex = variant === 'dark' ? '#000000' : '#ffffff';
-        if (hsl) {
-          const parts = hsl.split(/\s+/).map(v => parseFloat(v.replace('%', '')));
-          if (parts.length === 3 && parts.every(n => !isNaN(n))) {
-            hex = hslToHex(parts[0], parts[1], parts[2]);
-          }
-        }
-        await StatusBar.setBackgroundColor({ color: hex });
-        await StatusBar.setStyle({ style: variant === 'dark' ? Style.Light : Style.Dark });
-      } catch {
-        // Ignore errors when StatusBar plugin is unavailable
+    const mapThemeFamily = (c: ThemeColor): ThemeFamily => {
+      switch (c) {
+        case 'blue':
+        case 'red':
+        case 'green':
+        case 'purple':
+          return c;
+        default:
+          return 'default';
       }
     };
-    applyStatusBar();
-  }, [color, variant, currentMood]);
+    const themeKey = `${mapThemeFamily(color)}-${variant}` as ThemeKey;
+    applyStatusBarTheme(themeKey).catch(() => {});
+  }, [color, variant]);
 
   useDynamicTheme(currentMood, variant, color === 'ai-choice');
 

--- a/src/lib/statusBar.ts
+++ b/src/lib/statusBar.ts
@@ -1,0 +1,51 @@
+import { StatusBar, Style } from '@capacitor/status-bar';
+
+/** Relative luminance (WCAG) to decide light/dark icons */
+function isDarkBg(hex: string): boolean {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.slice(0, 2), 16) / 255;
+  const g = parseInt(h.slice(2, 4), 16) / 255;
+  const b = parseInt(h.slice(4, 6), 16) / 255;
+  const lin = (c: number) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+  const L = 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+  // Dark if luminance is low
+  return L < 0.5;
+}
+
+export type ThemeFamily = 'default' | 'red' | 'blue' | 'green' | 'purple';
+export type ThemeMode = 'light' | 'dark';
+export type ThemeKey = `${ThemeFamily}-${ThemeMode}`;
+
+/** Pick your exact status bar background per theme variant */
+const STATUSBAR_BG: Record<ThemeKey, string> = {
+  // Black / White
+  'default-dark': '#000000',
+  'default-light': '#FFFFFF',
+  // Red
+  'red-dark': '#7A0E1B',
+  'red-light': '#FFD5D9',
+  // Blue
+  'blue-dark': '#0A1C3A',
+  'blue-light': '#DDE9FF',
+  // Green
+  'green-dark': '#0F2D1E',
+  'green-light': '#D8F5E3',
+  // Purple
+  'purple-dark': '#0B0512',
+  'purple-light': '#EEDDF5',
+};
+
+/** Apply status bar based on your theme key */
+export async function applyStatusBarTheme(theme: ThemeKey) {
+  const color = STATUSBAR_BG[theme] ?? '#000000';
+
+  // keep content below the status bar (no overlap surprises)
+  await StatusBar.setOverlaysWebView({ overlay: false });
+
+  // background to match your header/theme
+  await StatusBar.setBackgroundColor({ color });
+
+  // icon color chosen from background luminance
+  const useLightIcons = isDarkBg(color);
+  await StatusBar.setStyle({ style: useLightIcons ? Style.Light : Style.Dark });
+}


### PR DESCRIPTION
## Summary
- add status bar theming utility to centralize color and icon logic
- invoke helper from theme provider to sync native bar with theme
- set Android boot status bar color and style to avoid startup flash

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a115467c80832a8f62ec738b3dceff