### PR TITLE
fix: add material design dependency

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
+    implementation "com.google.android.material:material:$materialVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -13,4 +13,5 @@ ext {
     androidxJunitVersion = '1.2.1'
     androidxEspressoCoreVersion = '3.6.1'
     cordovaAndroidVersion = '10.1.1'
+    materialVersion = '1.12.0'
 }


### PR DESCRIPTION
## Summary
- include Material Components library to support Theme.MaterialComponents references
- configure gradle variables for material version

## Testing
- `npx cap sync android`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a11b649b8c832ab50e0a523fb60851