### PR TITLE
Handle mobile network config & env vars for API access

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,9 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config">
 
         <activity
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -4,6 +4,9 @@ const config: CapacitorConfig = {
   appId: 'com.my.vivica',
   appName: 'vivica',
   webDir: 'dist',
+  server: {
+    androidScheme: 'https',
+  },
   plugins: {
     StatusBar: {
       style: 'DEFAULT',

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <title>Vivica - AI Assistant</title>
     <meta name="description" content="Vivica - Your intelligent AI assistant" />
     <meta name="author" content="Dustin" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://* capacitor:; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval';" />
     <link rel="manifest" href="manifest.json" />
     <link rel="icon" href="uploads/790c3ad0-f2a5-41ef-ac83-99cb6bdd3112.png" type="image/png" />
     <meta property="og:title" content="Vivica - AI Assistant" />

--- a/src/hooks/useOpenRouterModels.tsx
+++ b/src/hooks/useOpenRouterModels.tsx
@@ -30,7 +30,8 @@ export const useOpenRouterModels = () => {
     const fetchModels = async () => {
       try {
         setLoading(true);
-        const response = await fetch('https://openrouter.ai/api/v1/models');
+        const base = import.meta.env.VITE_API_URL || 'https://openrouter.ai/api/v1';
+        const response = await fetch(`${base}/models`);
         
         if (!response.ok) {
           throw new Error('Failed to fetch models');

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -39,7 +39,7 @@ export class ChatService {
   private apiKey: string;
   // apiKeyList is unused; keep until multi-key refactor
   private apiKeyList: string[];
-  private baseUrl = 'https://openrouter.ai/api/v1';
+  private baseUrl: string;
   private telemetry = {
     keyUsage: {} as Record<string, {success: number; failures: number; cooldownUntil?: number}>,
     lastUsedKey: '',
@@ -52,8 +52,10 @@ export class ChatService {
   // Track temporarily failing keys to avoid retrying them repeatedly
   private static keyCooldowns: Record<string, number> = {};
 
-  constructor(apiKey: string) {
-    this.apiKey = apiKey;
+  constructor(apiKey?: string, apiUrl?: string) {
+    this.apiKey = apiKey || import.meta.env.VITE_API_KEY || '';
+    this.apiKeyList = [];
+    this.baseUrl = apiUrl || import.meta.env.VITE_API_URL || 'https://openrouter.ai/api/v1';
     this.initKeyTelemetry();
   }
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -3,8 +3,14 @@ export function getPrimaryApiKey(): string {
   if (direct) return direct;
   try {
     const settings = JSON.parse(localStorage.getItem('vivica-settings') || '{}');
-    return settings.apiKey1 || settings.apiKey2 || settings.apiKey3 || '';
+    return (
+      settings.apiKey1 ||
+      settings.apiKey2 ||
+      settings.apiKey3 ||
+      import.meta.env.VITE_API_KEY ||
+      ''
+    );
   } catch {
-    return '';
+    return import.meta.env.VITE_API_KEY || '';
   }
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string;
+  readonly VITE_API_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- allow https origin by setting Capacitor server scheme
- fall back to env vars for API URL and key
- add CSP and Android network security rules for external requests

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a47189459c832ab3bf2b4dd086060d