### PR TITLE
fix: ensure status bar contrast for light and dark themes

### DIFF
--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!-- Dark theme status bar background -->
+  <color name="statusbar_color">#000000</color>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <!-- Maintain modern dark theme color palette -->
-  <color name="statusbar_color">#0B0512</color>
+  <!-- Light theme default status bar; dark variant defined in values-night -->
+  <color name="statusbar_color">#FFFFFF</color>
   <color name="primary_color">#1C1C1C</color>
   <color name="card_background">#292929</color>
   <color name="accent_color">#6200EE</color>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -3,8 +3,8 @@
     <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Default fallback color; JS/Capacitor will update dynamically -->
         <item name="android:statusBarColor">@color/statusbar_color</item>
-        <!-- Start with light icons to ensure contrast -->
-        <item name="android:windowLightStatusBar">false</item>
+        <!-- Light mode starts with dark icons for readability -->
+        <item name="android:windowLightStatusBar">true</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
         <item name="android:fitsSystemWindows">false</item>
     </style>


### PR DESCRIPTION
## Summary
- set default light theme status bar to white and dark theme to black
- enable dark icons on light mode status bar for better contrast

## Testing
- `npm run lint`
- `cd android && ./gradlew assembleDebug` *(fails: Could not read script '.../cordova.variables.gradle')*


------
https://chatgpt.com/codex/tasks/task_e_68a47df2d5fc832a927f037a648c65af