### PR TITLE
Fix GitHub Pages base path routing

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,6 +3,7 @@
   "short_name": "Vivica",
   "description": "Your intelligent AI assistant",
   "start_url": "./",
+  "scope": "./",
   "display": "standalone",
   "background_color": "#000000",
   "theme_color": "#000000",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ const AppContent = () => {
         <Toaster />
         <Sonner />
         <InstallPrompt />
-        <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <BrowserRouter basename={import.meta.env.BASE_URL} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="*" element={<NotFound />} />

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -16,9 +16,9 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+        <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
           Return to Home
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,9 +58,11 @@ function rssDevProxyPlugin(): Plugin {
 }
 
 // https://vitejs.dev/config/
+const defaultBase = '/VivicaAndroid/';
+
 export default defineConfig(({ mode }) => ({
-  // Allow overriding base for GitHub Pages via env
-  base: process.env.VITE_BASE || './',
+  // Default production builds to the GitHub Pages repo base, while allowing overrides for other targets.
+  base: process.env.VITE_BASE || (mode === 'production' ? defaultBase : '/'),
   preview: {
     headers: {
       'X-Content-Type-Options': 'nosniff',


### PR DESCRIPTION
### Motivation
- The site deployed to GitHub Pages was loading the app shell but resolving routes/assets as if hosted at `/`, causing 404s and the PWA install prompt to remain visible.
- For a repo-hosted Pages site the app must produce repo-aware asset and route paths (e.g. `/VivicaAndroid/`) so refreshes and direct links resolve correctly.

### Description
- Default Vite production `base` to the repo path by adding `const defaultBase = '/VivicaAndroid/';` and using `base: process.env.VITE_BASE || (mode === 'production' ? defaultBase : '/')` in `vite.config.ts` so builds target the correct Pages base by default.
- Make the React Router respect the deployed base by setting `BrowserRouter` `basename={import.meta.env.BASE_URL}` in `src/App.tsx` so client-side routing aligns with the Pages path.
- Replace the plain anchor in the 404 page with a router-aware `Link` in `src/pages/NotFound.tsx` so navigation back to home honors the router basename.
- Add a `scope` field to `public/manifest.json` (`"scope": "./"`) so the PWA manifest is repo-relative when served from GitHub Pages.

### Testing
- Ran `git diff --check` to validate changes and formatting, which passed.
- Attempted `npm run build` to verify the production build, but the local environment failed to complete the build due to an inconsistent/ vendored dependency tree (Vite/Tailwind internal module resolution errors), so full build verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba4ee39db4832aa326e8ce11024764)